### PR TITLE
Add support for latest version in get file

### DIFF
--- a/lib/BundleServer.js
+++ b/lib/BundleServer.js
@@ -55,6 +55,14 @@ function BundleServer(provider) {
   }
 
   if (provider.capabilities.getFile) {
+    app.get('/:app_id/file/latest/*', function (req, res, next) {
+      var file = req.params[0];
+      var app_id = req.params.app_id;
+      provider.getLatestFile(app_id, file).then(function (buffer) {
+        res.set('Content-Type', mime.lookup(file));
+        res.send(buffer);
+      }).catch(next);
+    });
     app.get('/:app_id/file/:version/*', function (req, res, next) {
       var file = req.params[0];
       var app_id = req.params.app_id;

--- a/lib/providers/ArchiveProvider.js
+++ b/lib/providers/ArchiveProvider.js
@@ -191,6 +191,16 @@ ArchiveProvider.prototype.getFile = function getFile(name, version, file) {
   });
 };
 
+/**
+ * read a file as a buffer for latest version
+ */
+
+ArchiveProvider.prototype.getLatestFile = function getLatestFile(name, file) {
+  return this.getLatestBundle(name).then(function (archivePath) {
+    return zip.readFile(archivePath, file);
+  });
+};
+
 // ArchiveProvider capablities
 var capabilities = ProviderCapabilities.create({
   watchable: false,

--- a/lib/providers/Provider.js
+++ b/lib/providers/Provider.js
@@ -121,4 +121,18 @@ Provider.prototype.getFile = function (appName, appVersion, file) {
   return Promise.reject(new UnimplementedError('base provider'));
 };
 
+/**
+ * Get a file for an app at latest version
+ *
+ * @abstract
+ * @param {String} appName - application name
+ * @param {String} file - relative path to file
+ *
+ * @return {Promise<Buffer>}
+ */
+
+Provider.prototype.getLatestFile = function (appName, file) {
+  return Promise.reject(new UnimplementedError('base provider'));
+};
+
 module.exports = Provider;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reference Tealeaf bundle service",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive -R nyan test",
+    "test": "mocha --recursive -R spec test",
     "watch": "node testWatcher.js",
     "make_docs": "jsdoc -c jsdoc.json -R README.md -d docs -r lib"
   },

--- a/test/functional/BundleServer.js
+++ b/test/functional/BundleServer.js
@@ -152,9 +152,9 @@ describe('BundleServer', function () {
   });
 
   describe('/:app_id/file/:version/:path', function () {
-    it('returns manifest when path is manifest.json', function (done) {
+    function requestManifest(version, done) {
       request
-      .get(location('/shooter/file/v2.0.0/manifest.json'))
+      .get(location('/shooter/file/' + version + '/manifest.json'))
       .end(function (err, res) {
         assert.equal(res.header['content-type'], 'application/json');
         var manifest = JSON.parse(res.text);
@@ -162,6 +162,13 @@ describe('BundleServer', function () {
         assert(manifest.shortName);
         done();
       });
+    }
+    it('returns manifest when path is manifest.json', function (done) {
+      requestManifest('v2.0.0', done);
+    });
+
+    it('handles the :version latest', function (done) {
+      requestManifest('latest', done);
     });
 
     it('sends a 404 when file is not found', function (done) {

--- a/test/unit/ProviderTests.js
+++ b/test/unit/ProviderTests.js
@@ -131,17 +131,7 @@ function providerUnitTests(provider) {
     });
 
     if (provider.capabilities.getFile) {
-      describe('#getFile', function () {
-        before(function () {
-          this.getFile = function () {
-            return this.provider.getFile(appName, version , manifestFile);
-          };
-        });
-
-        after(function () {
-          this.getFile = void 0;
-        });
-
+      function createGetFileTests() {
         it('returns a promise', function () {
           assert(this.getFile() instanceof Promise);
         });
@@ -164,6 +154,34 @@ function providerUnitTests(provider) {
             assert(manifest.shortName);
           }).then(done, done);
         });
+      }
+
+      describe('#getFile', function () {
+        before(function () {
+          this.getFile = function () {
+            return this.provider.getFile(appName, version , manifestFile);
+          };
+        });
+
+        after(function () {
+          this.getFile = void 0;
+        });
+
+        createGetFileTests.call(this);
+      });
+
+      describe('#getLatestFile', function () {
+        before(function () {
+          this.getFile = function () {
+            return this.provider.getLatestFile(appName, manifestFile);
+          };
+        });
+
+        after(function () {
+          this.getFile = void 0;
+        });
+
+        createGetFileTests.call(this);
       });
     }
 


### PR DESCRIPTION
The get file endpoint now handles the `:version` "latest" by calling `getLatestFile` on the provider instead of `getFile`.

Resolves #1.
